### PR TITLE
Fix for tl 0.15.1+dev

### DIFF
--- a/tabular.lua
+++ b/tabular.lua
@@ -236,7 +236,7 @@ show_as_columns = function(t, bgcolor, seen, ids, column_order, skip_header)
          local line = { draw.V }
          for _, cname in ipairs(column_names) do
             local row = columns[cname][i]
-            output_cell(line, cname, row and row[math.floor(h)] or "", bgcolor and colors[(i % #colors) + 1])
+            output_cell(line, cname, row and row[h] or "", bgcolor and colors[(i % #colors) + 1])
          end
          output_line(out, table.concat(line))
       end

--- a/tabular.lua
+++ b/tabular.lua
@@ -1,6 +1,6 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local math = _tl_compat and _tl_compat.math or math; local os = _tl_compat and _tl_compat.os or os; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local utf8 = _tl_compat and _tl_compat.utf8 or utf8; local tabular = {}
 
-local AnsiColors = {}
+
 
 
 
@@ -63,7 +63,7 @@ if (os.getenv("LANG") or ""):upper():match("UTF%-?8") then
 
 end
 
-local Output = {}
+
 
 
 
@@ -80,7 +80,7 @@ local function escape_chars(c)
    return "\\" .. string.byte(c)
 end
 
-local Pair = {}
+
 
 local function show_as_list(t, color, seen, ids, skip_array)
    local tt = {}
@@ -136,7 +136,7 @@ local function show_primitive(t)
    return out
 end
 
-local Row = {}
+
 
 
 
@@ -236,7 +236,7 @@ show_as_columns = function(t, bgcolor, seen, ids, column_order, skip_header)
          local line = { draw.V }
          for _, cname in ipairs(column_names) do
             local row = columns[cname][i]
-            output_cell(line, cname, row and row[h] or "", bgcolor and colors[(i % #colors) + 1])
+            output_cell(line, cname, row and row[math.floor(h)] or "", bgcolor and colors[(i % #colors) + 1])
          end
          output_line(out, table.concat(line))
       end
@@ -266,7 +266,7 @@ show = function(t, color, seen, ids, column_order)
 
    if type(t) == "table" then
       local tt = t
-      if #tt > 0 and type(tt[1]) == "table" then
+      if #(tt) > 0 and type(tt[1]) == "table" then
          return show_as_columns(tt, color, seen, ids, column_order)
       else
          return show_as_list(tt, color, seen, ids)

--- a/tabular.tl
+++ b/tabular.tl
@@ -26,7 +26,7 @@ local colors: {string} = {
   ansicolors.noReset("%{white}"),
 }
 
-local function strlen(s: string): number
+local function strlen(s: string): integer
   s = s:gsub("\27[^m]*m", "")
   return #s
 end
@@ -48,7 +48,7 @@ if (os.getenv("LANG") or ""):upper():match("UTF%-?8") then
     X = "┼",
   }
 
-  strlen = function(s: string): number
+  strlen = function(s: string): integer
     s = s:gsub("\27[^m]*m", "")
     return utf8.len(s) or #s
   end
@@ -236,7 +236,7 @@ show_as_columns = function(t: {{any:any}}, bgcolor: string, seen: {any:boolean},
       local line = { draw.V }
       for _, cname in ipairs(column_names) do
         local row = columns[cname][i]
-        output_cell(line, cname, row and row[h] or "", bgcolor and colors[(i % #colors) + 1])
+        output_cell(line, cname, row and row[math.floor(h)] or "", bgcolor and colors[(i % #colors) + 1])
       end
       output_line(out, table.concat(line))
     end
@@ -266,7 +266,7 @@ show = function(t: any, color: string, seen: {any:boolean}, ids: {any:number}, c
 
   if type(t) == "table" then
     local tt = t as {any:any}
-    if #tt > 0 and type(tt[1]) == "table" then
+    if #(tt as {any}) > 0 and type(tt[1]) == "table" then
       return show_as_columns(tt as {{any:any}}, color, seen, ids, column_order)
     else
       return show_as_list(tt, color, seen, ids)
@@ -302,4 +302,4 @@ if arg and arg[0]:match("tabular%..*$") then
   os.exit(0)
 end
 
-return setmetatable( tabular, { __call = function(_, ...): string return tabular.show(...) end } )
+return setmetatable( tabular, { __call = function(_, ...:any): string return tabular.show(... as {string}) end } )

--- a/tabular.tl
+++ b/tabular.tl
@@ -143,7 +143,7 @@ end
 
 show_as_columns = function(t: {{any:any}}, bgcolor: string, seen: {any:boolean}, ids: {any:number}, column_order: {string}, skip_header: boolean): Output
   local columns: {string:Row} = {}
-  local row_heights: {number:number} = {}
+  local row_heights: {integer:integer} = {}
 
   local column_names: {string}
   local column_set: {string:boolean}
@@ -236,7 +236,7 @@ show_as_columns = function(t: {{any:any}}, bgcolor: string, seen: {any:boolean},
       local line = { draw.V }
       for _, cname in ipairs(column_names) do
         local row = columns[cname][i]
-        output_cell(line, cname, row and row[math.floor(h)] or "", bgcolor and colors[(i % #colors) + 1])
+        output_cell(line, cname, row and row[h] or "", bgcolor and colors[(i % #colors) + 1])
       end
       output_line(out, table.concat(line))
     end


### PR DESCRIPTION
Hello! For revision 9de53e8d18145c21c8dabeedba253df74f262191 with teal `0.15.1+dev` writes:
```
tabular.tl|94 col 37| argument 2: got number, expected integer                                                                                                                                        
tabular.tl|239 col 46| cannot index object of type Output with number                                                                                                                                 
tabular.tl|269 col 8| using the '#' operator on this map will always return 0                                                                                                                         
tabular.tl|305 col 86| argument 2: got <unknown type>, expected {string}                                                                                                                              
```
I propose solution 68d2b842367a7c32af073880b907c67de1807362